### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-        run: npx semantic-release
+        run: npx -p node@lts -c "npx semantic-release"


### PR DESCRIPTION
semantic-release@20.0.2: node version >=18 is required. Found v16.19.0.
More information on https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md