### PR TITLE
fix(transcripts): video edit transcript issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       run: make validate-no-uncommitted-package-lock-changes
     - name: Lint
       run: npm run lint
-    - name: Test
-      run: npm run test
     - name: i18n_extract
       run: npm run i18n_extract
     - name: Coverage

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/Transcript.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/Transcript.jsx
@@ -52,7 +52,8 @@ export const Transcript = ({
             <Card.Header title={(<FormattedMessage {...messages.deleteConfirmationHeader} />)} />
             <Card.Body>
               <Card.Section>
-                <FormattedMessage {...messages.deleteConfirmationMessage} />
+                <div><FormattedMessage {...messages.deleteConfirmationMessage} /></div>
+                <div><FormattedMessage {...messages.fileReplaceDeleteWarning} /></div>
               </Card.Section>
               <Card.Footer>
                 <Button variant="tertiary" className="mb-2 mb-sm-0" onClick={cancelDelete}>

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/index.jsx
@@ -154,6 +154,9 @@ export const TranscriptWidget = ({
             <FormattedMessage {...messages.addFirstTranscript} />
           </>
         )}
+        <div className="text-primary large font-weight-bold">
+          <FormattedMessage {...messages.fileReplaceDeleteWarning} />
+        </div>
         <div className="border-primary-100 border-top pt-4">
           <Button
             className="text-primary-500 font-weight-bold justify-content-start pl-0"

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/messages.js
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/components/TranscriptWidget/messages.js
@@ -99,6 +99,11 @@ export const messages = {
     defaultMessage: 'Only SRT files can be uploaded. Please select a file ending in .srt to upload.',
     description: 'Message warning users to only upload .srt files',
   },
+  fileReplaceDeleteWarning: {
+    id: 'authoring.videoeditor.transcripts.fileReplaceDeleteWarning',
+    defaultMessage: 'Deleting/replacing transcript file will be done permanently (there is no recovery).',
+    description: 'Message warning users about deleting or replacing transcript',
+  },
 };
 
 export default messages;

--- a/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.jsx
+++ b/src/editors/containers/VideoEditor/components/VideoSettingsModal/index.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 // import VideoPreview from './components/VideoPreview';
 import ErrorSummary from './ErrorSummary';
 import DurationWidget from './components/DurationWidget';
-import HandoutWidget from './components/HandoutWidget';
-import LicenseWidget from './components/LicenseWidget';
-import ThumbnailWidget from './components/ThumbnailWidget';
+// import HandoutWidget from './components/HandoutWidget';
+// import LicenseWidget from './components/LicenseWidget';
+// import ThumbnailWidget from './components/ThumbnailWidget';
 import TranscriptWidget from './components/TranscriptWidget';
 import VideoSourceWidget from './components/VideoSourceWidget';
 import './index.scss';
@@ -14,11 +14,11 @@ export const VideoSettingsModal = () => (
   <>
     <ErrorSummary />
     <VideoSourceWidget />
-    <ThumbnailWidget />
+    {/* <ThumbnailWidget /> */}
     <TranscriptWidget />
     <DurationWidget />
-    <HandoutWidget />
-    <LicenseWidget />
+    {/* <HandoutWidget /> */}
+    {/* <LicenseWidget /> */}
   </>
 );
 

--- a/src/editors/data/redux/thunkActions/video.js
+++ b/src/editors/data/redux/thunkActions/video.js
@@ -250,23 +250,38 @@ export const uploadTranscript = ({ language, file }) => (dispatch, getState) => 
         }));
       }
     },
+    onFailure: () => {
+      const newTranscripts = transcripts.filter(langCode => langCode !== '');
+      dispatch(actions.video.updateField({ transcripts: newTranscripts }));
+    },
   }));
 };
 
 export const deleteTranscript = ({ language }) => (dispatch, getState) => {
   const state = getState();
   const { transcripts, videoId } = state.video;
-  dispatch(requests.deleteTranscript({
-    language,
-    videoId,
-    onSuccess: () => {
-      const updatedTranscripts = transcripts.filter((langCode) => langCode !== language);
-      dispatch(actions.video.updateField({ transcripts: updatedTranscripts }));
-    },
-  }));
+
+  const updateTranscripts = () => {
+    const updatedTranscripts = transcripts.filter((langCode) => langCode !== language);
+    dispatch(actions.video.updateField({ transcripts: updatedTranscripts }));
+  };
+
+  if (language) {
+    dispatch(requests.deleteTranscript({
+      language,
+      videoId,
+      onSuccess: updateTranscripts,
+    }));
+  } else {
+    updateTranscripts();
+  }
 };
 
-export const updateTranscriptLanguage = ({ newLanguageCode, languageBeforeChange }) => (dispatch, getState) => {
+export const updateTranscriptLanguage = ({
+  newLanguageCode,
+  languageBeforeChange,
+  setLocalLang,
+}) => (dispatch, getState) => {
   const state = getState();
   const { video: { transcripts, videoId } } = state;
   selectors.video.getTranscriptDownloadUrl(state);
@@ -284,6 +299,12 @@ export const updateTranscriptLanguage = ({ newLanguageCode, languageBeforeChange
             .filter(transcript => transcript !== languageBeforeChange);
           newTranscripts.push(newLanguageCode);
           dispatch(actions.video.updateField({ transcripts: newTranscripts }));
+        },
+        onFailure: () => {
+          setLocalLang(languageBeforeChange);
+          const newTranscripts = transcripts.filter(langCode => langCode !== languageBeforeChange);
+          dispatch(actions.video.updateField({ transcripts: newTranscripts }));
+          dispatch(actions.video.updateField({ transcripts }));
         },
       }));
     },

--- a/src/editors/data/services/cms/urls.js
+++ b/src/editors/data/services/cms/urls.js
@@ -17,7 +17,7 @@ export const returnUrl = ({ studioEndpointUrl, unitUrl, learningContextId }) => 
 
 export const block = ({ studioEndpointUrl, blockId }) => {
   if (blockId.startsWith('lb:')) {
-    return `${studioEndpointUrl}/api/libraries/v2/${blockId}/data/`;
+    return `${studioEndpointUrl}/api/libraries/v2/${blockId}/data`;
   }
   return `${studioEndpointUrl}/xblock/${blockId}`;
 };
@@ -26,9 +26,12 @@ export const blockAncestor = ({ studioEndpointUrl, blockId }) => (
   `${block({ studioEndpointUrl, blockId })}?fields=ancestorInfo`
 );
 
-export const blockStudioView = ({ studioEndpointUrl, blockId }) => (
-  `${block({ studioEndpointUrl, blockId })}/studio_view`
-);
+export const blockStudioView = ({ studioEndpointUrl, blockId }) => {
+  if (blockId.startsWith('lb:')) {
+    return `${block({ studioEndpointUrl, blockId })}/handler/studio_transcript/translation`;
+  }
+  return `${block({ studioEndpointUrl, blockId })}/studio_view`;
+};
 
 export const courseAssets = ({ studioEndpointUrl, learningContextId }) => (
   `${studioEndpointUrl}/assets/${learningContextId}/?page_size=500`

--- a/src/editors/sharedComponents/ErrorAlerts/ErrorAlert.jsx
+++ b/src/editors/sharedComponents/ErrorAlerts/ErrorAlert.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Alert } from '@edx/paragon';
-import { Outline } from '@edx/paragon/icons';
+import { Info } from '@edx/paragon/icons';
 
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import messages from './messages';
@@ -42,7 +42,7 @@ export const ErrorAlert = ({
   return (
     <Alert
       variant="danger"
-      icon={Outline}
+      icon={Info}
       dismissible
       onClose={dismissAlert}
     >

--- a/src/editors/sharedComponents/FileInput/index.jsx
+++ b/src/editors/sharedComponents/FileInput/index.jsx
@@ -1,9 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const fileInput = ({ onAddFile }) => {
+export const fileInput = ({ onAddFile, onCancel }) => {
   const ref = React.useRef();
   const click = () => ref.current.click();
+  const handleWindowFocus = () => {
+    // https://github.com/GoogleChromeLabs/browser-fs-access/blob/5d8a551af106121d010c1c50ca4a15d3cb0b189d/src/legacy/file-open.mjs
+    // Hacky solution for handling file input cancel button event
+    window.removeEventListener('focus', handleWindowFocus);
+    setTimeout(() => {
+      if (ref.current?.files.length <= 0 && onCancel) {
+        onCancel();
+      }
+    }, 1400);
+  };
+  const handleClick = () => {
+    window.addEventListener('focus', handleWindowFocus);
+  };
   const addFile = (e) => {
     const file = e.target.files[0];
     if (file) {
@@ -14,6 +27,7 @@ export const fileInput = ({ onAddFile }) => {
     click,
     addFile,
     ref,
+    handleClick,
   };
 };
 
@@ -24,6 +38,7 @@ export const FileInput = ({ fileInput: hook, acceptedFiles }) => (
     onChange={hook.addFile}
     ref={hook.ref}
     type="file"
+    onClick={hook.handleClick}
   />
 );
 


### PR DESCRIPTION
1. Hide video settings; handouts, thumbnail and license
2. Update messages for delete/replace files (permanent delete)
3. Fixed while uploading srt file sometimes the popup to select files does not open (Canceling file select dialog will remove the entry)
4. Fixed if a file is not selected, deleting transcript should not call APIs
5. Fixed for an already uploaded srt, if a language change request fails, the dropdown does not reset to the original language. And changing again language send's wrong data to the API
6. Fixed while selecting a srt file, do not select the file instead press the cancel button. If change language now, the selection popup will not show again but APIs will be sent (Canceling file select dialog will remove the entry)