### PR TITLE
fix: problem block unlimited attempts option saving 0 attempts

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -121,6 +121,10 @@ export const scoringCardHooks = (scoring, updateSettings) => {
     if (attemptNumber > 0) {
       unlimitedAttempts = false;
     }
+    if (!attemptNumber) {
+      // saving 0 attempts will disable submit button
+      attemptNumber = '';
+    }
     updateSettings({ scoring: { ...scoring, attempts: { number: attemptNumber, unlimited: unlimitedAttempts } } });
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -18,7 +18,7 @@ export const ScoringCard = ({
     <SettingsOption
       title={intl.formatMessage(messages.scoringSettingsTitle)}
       summary={intl.formatMessage(messages.scoringSummary,
-        { attempts: scoring.attempts.number, weight: scoring.weight })}
+        { attempts: scoring.attempts.number ? scoring.attempts.number : 0, weight: scoring.weight })}
     >
       <Form.Group>
         <Form.Control

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -17,7 +17,7 @@ const initialState = {
       weight: 0,
       attempts: {
         unlimited: true,
-        number: 0,
+        number: '',
       },
     },
     hints: [],


### PR DESCRIPTION
Saving 0 attempts disables the problem (MCQs) block's submit button. Empty `''` string, which translates to `None` in backend, is being saved to now.